### PR TITLE
Add elements needed in json-files

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -104,6 +104,10 @@ const jsonld = {
       "@id": "dct:isReplacedBy",
       "@container": "@set",
     },
+    url: {
+      "@id": "schema:url",
+      "@container": "@set",
+    },
   },
 }
 

--- a/src/queries.js
+++ b/src/queries.js
@@ -123,6 +123,9 @@ module.exports.allConcept = (inScheme, languages) => `
           isReplacedBy {
             id
           }
+          url {
+            id
+          }
         }
       }
     }
@@ -183,6 +186,18 @@ module.exports.allConceptScheme = (languages) => `
       ${[...languages].join(" ")}
     }
     deprecated
+    url {
+      id
+    }
+    exactMatch {
+      id
+    }
+    relatedMatch {
+      id
+    }
+    broadMatch {
+      id
+    }
   }
 `
 module.exports.tokenizer = `{


### PR DESCRIPTION
Unsere Tools verwenden einige Attribute in index.json-Dateien, die von SkoHub selbst nicht dorthin geschrieben werden. Dafür haben wir nun einen kleinen Patch geschrieben.